### PR TITLE
Added Denso gripper service node to control the gripper through BCap

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -1,0 +1,25 @@
+# Commands
+
+## Overview
+This document provides an overview of the commands available for controlling Denso robots using ROS 2. The commands are designed to facilitate communication between the ROS 2 framework and Denso robot controllers, enabling users to perform various operations such as moving the robot, setting parameters, and retrieving status information.
+
+## Run Moveit and Control Gripper
+
+```bash
+ros2 launch bcap_service bcap_service.launch.py model:=cobotta ip_address:=172.16.6.103
+
+ros2 launch denso_robot_bringup denso_robot_bringup.launch.py model:=cobotta sim:=false ip_address:=172.16.6.103 send_format:=0 recv_format:=2
+
+ros2 launch denso_robot_bringup denso_gripper_bringup.launch.py
+```
+
+## Open and Close gripper
+
+```bash
+ros2 service call /gripper_service bcap_service_interfaces/srv/Gripper "value: 30
+speed: 10" 
+requester: making request: bcap_service_interfaces.srv.Gripper_Request(value=30, speed=10)
+
+response:
+bcap_service_interfaces.srv.Gripper_Response(success=True, message='Gripper moved successfully.')
+```

--- a/bcap_service_interfaces/CMakeLists.txt
+++ b/bcap_service_interfaces/CMakeLists.txt
@@ -25,7 +25,8 @@ find_package(rclcpp REQUIRED)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
   "msg/Variant.msg"
-  "srv/Bcap.srv")
+  "srv/Bcap.srv"
+  "srv/Gripper.srv")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/bcap_service_interfaces/srv/Gripper.srv
+++ b/bcap_service_interfaces/srv/Gripper.srv
@@ -1,0 +1,5 @@
+uint8 value  # 0 = fully closed, 30 = fully open
+uint8 speed # 0-100 speed percentage
+---
+bool success
+string message

--- a/denso_robot_bringup/launch/denso_gripper_bringup.launch.py
+++ b/denso_robot_bringup/launch/denso_gripper_bringup.launch.py
@@ -1,0 +1,14 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+#!/usr/bin/env python3
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='denso_robot_control',
+            executable='denso_gripper_control_node',
+            name='denso_gripper_control_node',
+            output='screen',
+        )
+    ])

--- a/denso_robot_control/CMakeLists.txt
+++ b/denso_robot_control/CMakeLists.txt
@@ -87,6 +87,11 @@ ament_target_dependencies(
 
 pluginlib_export_plugin_description_file(hardware_interface denso_hardware_interface_plugin.xml)
 
+add_executable(denso_gripper_control_node src/denso_gripper_control.cpp)
+ament_target_dependencies(
+  denso_gripper_control_node
+  ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
 
 #=============
 # Install
@@ -113,6 +118,10 @@ install(
   RUNTIME DESTINATION lib/${PROJECT_NAME}
   INCLUDES DESTINATION include)
 
+install(TARGETS
+  denso_gripper_control_node
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 #=============
 # Export

--- a/denso_robot_control/include/denso_robot_control/denso_gripper_control.hpp
+++ b/denso_robot_control/include/denso_robot_control/denso_gripper_control.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <bcap_service_interfaces/msg/variant.hpp>
+#include <bcap_service_interfaces/srv/bcap.hpp>
+#include <bcap_service_interfaces/srv/gripper.hpp>
+
+namespace denso_gripper_control {
+    class DensoGripperControl : public rclcpp::Node {
+    public:
+        DensoGripperControl();
+        ~DensoGripperControl();
+    private:
+        void on_gripper_service(const std::shared_ptr<bcap_service_interfaces::srv::Gripper::Request> request,
+                                std::shared_ptr<bcap_service_interfaces::srv::Gripper::Response> response);
+        rclcpp::Service<bcap_service_interfaces::srv::Gripper>::SharedPtr gripper_service_;
+        rclcpp::Client<bcap_service_interfaces::srv::Bcap>::SharedPtr bcap_client_;
+        std::shared_ptr<bcap_service_interfaces::srv::Bcap::Request> bcap_request = std::make_shared<bcap_service_interfaces::srv::Bcap::Request>();
+        std::shared_ptr<bcap_service_interfaces::srv::Bcap::Request> gripper_request = std::make_shared<bcap_service_interfaces::srv::Bcap::Request>();
+        std::string robot_id_;
+    };
+}

--- a/denso_robot_control/src/denso_gripper_control.cpp
+++ b/denso_robot_control/src/denso_gripper_control.cpp
@@ -1,0 +1,84 @@
+#include "denso_robot_control/denso_gripper_control.hpp"
+
+namespace denso_gripper_control {
+    DensoGripperControl::DensoGripperControl() : Node("denso_gripper_control") {
+        bcap_client_ = this->create_client<bcap_service_interfaces::srv::Bcap>("/cobotta/bcap_service");
+        while (!bcap_client_->wait_for_service(std::chrono::seconds(1))) {
+            RCLCPP_INFO(this->get_logger(), "Waiting for BCAP service to be available...");
+        }
+        // prepare bcap connect request
+        bcap_request->func_id = 3;
+        bcap_request->vnt_args.resize(4);
+        bcap_request->vnt_args[0].vt = 8;
+        bcap_request->vnt_args[0].value = "b-CAP";
+        bcap_request->vnt_args[1].vt = 8;
+        bcap_request->vnt_args[1].value = "CaoProv.DENSO.VRC";
+        bcap_request->vnt_args[2].vt = 8;
+        bcap_request->vnt_args[2].value = "localhost";
+        bcap_request->vnt_args[3].vt = 8;
+        bcap_request->vnt_args[3].value = "";
+
+        
+
+        RCLCPP_INFO(this->get_logger(), "Sending BCAP connect request...");
+        auto future = bcap_client_->async_send_request(bcap_request);
+        if (rclcpp::spin_until_future_complete(this->get_node_base_interface(), future) ==
+            rclcpp::FutureReturnCode::SUCCESS) {
+            auto bcap_response = future.get();
+            robot_id_ = bcap_response->vnt_ret.value;
+            if (robot_id_.empty()) {
+                RCLCPP_ERROR(this->get_logger(), "BCAP connect failed. Please relaunch the bcap_service launch file");
+                exit(1);
+                return;
+            }
+            else {
+                RCLCPP_INFO(this->get_logger(), "BCAP connected. Robot ID: %s",
+                            robot_id_.c_str());
+            }
+        } else {
+            RCLCPP_ERROR(this->get_logger(), "Failed to connect to BCAP service.");
+        }
+
+        // prepare gripper request
+        gripper_request->func_id = 17;
+        gripper_request->vnt_args.resize(3);
+        gripper_request->vnt_args[0].vt = 19;
+        gripper_request->vnt_args[0].value = robot_id_;
+        gripper_request->vnt_args[1].vt = 8;
+        gripper_request->vnt_args[1].value = "HandMoveA";
+        gripper_request->vnt_args[2].vt = 8195;  // VT_UI1
+        gripper_request->vnt_args[2].value = "";  // Placeholder for gripper position
+
+        gripper_service_ = this->create_service<bcap_service_interfaces::srv::Gripper>(
+            "gripper_service", std::bind(&DensoGripperControl::on_gripper_service, this,
+                                         std::placeholders::_1, std::placeholders::_2));
+        RCLCPP_INFO(this->get_logger(), "Denso Gripper Control Node has been started.");
+    }
+
+    DensoGripperControl::~DensoGripperControl() {
+        RCLCPP_INFO(this->get_logger(), "Denso Gripper Control Node has been stopped.");
+    }
+
+    void DensoGripperControl::on_gripper_service(
+        const std::shared_ptr<bcap_service_interfaces::srv::Gripper::Request> request,
+        std::shared_ptr<bcap_service_interfaces::srv::Gripper::Response> response) {
+        RCLCPP_INFO(this->get_logger(), "Gripper service called with value: %d, speed: %d", request->value, request->speed);
+        gripper_request->vnt_args[2].value = std::to_string(request->value) + "," + std::to_string(request->speed);
+        auto future = bcap_client_->async_send_request(gripper_request);
+
+        if (future.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+            auto bcap_response = future.get();
+        }
+        response->success = true;
+        response->message = "Gripper moved successfully.";
+        RCLCPP_INFO(this->get_logger(), "Gripper moved successfully.");
+    }
+}
+
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<denso_gripper_control::DensoGripperControl>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
Added a Gripper service definition and the Denso Gripper Control node, update the build to generate interfaces, and add usage docs and a launch file for Denso robots.

What this changes

API: Add a Gripper service definition (srv/) to expose gripper open/close/commands to callers.
Build: Update CMake / interface-generation config so the new service is generated and installed correctly.
Implementation: Add a Denso Gripper Control node that implements the Gripper service and exposes the gripper control commands.
Launch & docs: Add a gripper launch file for Denso robots and documentation describing the available gripper commands and how to call the service.

## Usage
```bash
ros2 launch bcap_service bcap_service.launch.py model:=cobotta ip_address:=<ip_address>

ros2 launch denso_robot_bringup denso_gripper_bringup.launch.py

ros2 service call /gripper_service bcap_service_interfaces/srv/Gripper "value: 30
speed: 10" 
```

### References
- https://github.com/DENSORobot/denso_robot_ros/issues/13